### PR TITLE
Keep the portrait in colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ the rendered box, so `cover` neither upscales nor trims the sides. Below 640px
 the layout stacks and the photo takes a fixed 4:5 instead, since there's no
 text column to match.
 
-It sits desaturated and fades to full colour on hover. If the files are
-missing, the portrait column removes itself and the page falls back to the
-single-column layout rather than showing a broken image.
+It renders in full colour. If the files are missing, the portrait column
+removes itself and the page falls back to the single-column layout rather than
+showing a broken image.
 
 To swap the photo, regenerate both sizes from the same crop and update
 `PORTRAIT.alt` in `src/site.ts`.

--- a/src/App.css
+++ b/src/App.css
@@ -154,12 +154,6 @@
   object-fit: cover;
   border-radius: 4px;
   background-color: var(--ink-faint);
-  filter: grayscale(1);
-  transition: filter 600ms cubic-bezier(0.2, 0.7, 0.2, 1);
-}
-
-.portrait img:hover {
-  filter: grayscale(0);
 }
 
 /* ---------------------------------------------------------------------------
@@ -360,10 +354,6 @@
   .icon-link,
   .company-note span {
     animation: none !important;
-  }
-
-  .portrait img {
-    transition-duration: 1ms;
   }
 
   .icon-link {


### PR DESCRIPTION
Drops the grayscale filter so the photo renders as shot.

The hover-to-colour transition goes with it — that was the only reason the filter existed — and so does the `prefers-reduced-motion` override that shortened it. The image now has no filter and no hover state at all.

## Verification

Checked in both light and dark:

- computed `filter` is `none`, before and after hover
- sampled the rendered pixels: max saturation **1.0**, ~50% of them visibly colourful
- layout untouched — photo and prose still both **387px**
- no console errors, lint and typecheck clean

## Also, the résumé exposure is closed

Unrelated to this change, but worth recording: PR #7 merged and deployed, and I re-checked the live file — `https://vishesh-gupta.github.io/resume.pdf` no longer contains the phone number. The window where it was public has ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq4VW82XhtiZcbezGScgBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xq4VW82XhtiZcbezGScgBf)_